### PR TITLE
Fixed ConnectionPool initialization error masking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!--dependency versions -->
-        <celesta.version>7.0.10</celesta.version>
+        <celesta.version>7.0.11</celesta.version>
         <checkstyle.version>8.10</checkstyle.version>
         <junit.platform.version>1.0.0</junit.platform.version>
         <junit.version>5.1.0</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!--dependency versions -->
-        <celesta.version>7.0.7</celesta.version>
+        <celesta.version>7.0.10</celesta.version>
         <checkstyle.version>8.10</checkstyle.version>
         <junit.platform.version>1.0.0</junit.platform.version>
         <junit.version>5.1.0</junit.version>
@@ -146,6 +146,7 @@
 
         <pluginManagement>
             <plugins>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!--dependency versions -->
-        <celesta.version>7.0.1</celesta.version>
+        <celesta.version>7.0.7</celesta.version>
         <checkstyle.version>8.10</checkstyle.version>
         <junit.platform.version>1.0.0</junit.platform.version>
         <junit.version>5.1.0</junit.version>

--- a/src/main/java/ru/curs/celesta/transaction/CelestaTransactionAspect.java
+++ b/src/main/java/ru/curs/celesta/transaction/CelestaTransactionAspect.java
@@ -31,8 +31,8 @@ public final class CelestaTransactionAspect {
     public Object execEntryPoint(ProceedingJoinPoint joinPoint) throws Throwable {
         Optional<CallContext> cc =
                 Arrays.stream(joinPoint.getArgs())
-                        .filter(arg -> arg instanceof CallContext)
-                        .map(arg -> (CallContext) arg)
+                        .filter(CallContext.class::isInstance)
+                        .map(CallContext.class::cast)
                         .findFirst();
         if (cc.isPresent()) {
             return proceedInTransaction(cc.get(), joinPoint);

--- a/src/main/java/ru/curs/celesta/transaction/CelestaTransactionAspect.java
+++ b/src/main/java/ru/curs/celesta/transaction/CelestaTransactionAspect.java
@@ -34,10 +34,11 @@ public final class CelestaTransactionAspect {
                         .filter(arg -> arg instanceof CallContext)
                         .map(arg -> (CallContext) arg)
                         .findFirst();
-        if (cc.isPresent()){
+        if (cc.isPresent()) {
             return proceedInTransaction(cc.get(), joinPoint);
-        } else
+        } else {
             return joinPoint.proceed();
+        }
     }
 
     private Object proceedInTransaction(CallContext c, ProceedingJoinPoint joinPoint) throws Throwable {

--- a/src/main/java/ru/curs/celesta/transaction/CelestaTransactionAspect.java
+++ b/src/main/java/ru/curs/celesta/transaction/CelestaTransactionAspect.java
@@ -32,7 +32,7 @@ public final class CelestaTransactionAspect {
         Optional<CallContext> cc =
                 Arrays.stream(joinPoint.getArgs())
                         .filter(arg -> arg instanceof CallContext)
-                        .map(arg -> (CallContext)arg)
+                        .map(arg -> (CallContext) arg)
                         .findFirst();
         cc.ifPresent(c -> c.activate(celesta, joinPoint.getSignature().toShortString()));
         try {

--- a/src/test/java/ru/curs/celesta/transaction/CelestaTransactionTest.java
+++ b/src/test/java/ru/curs/celesta/transaction/CelestaTransactionTest.java
@@ -1,5 +1,7 @@
 package ru.curs.celesta.transaction;
 
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.context.annotation.UserConfigurations;
@@ -11,7 +13,15 @@ import ru.curs.celesta.spring.boot.autoconfigure.CelestaAutoConfiguration;
 
 import java.sql.SQLException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class CelestaTransactionTest {
     private static final String SCORE_PATH = "classpath:score";
@@ -78,8 +88,51 @@ public class CelestaTransactionTest {
                 }));
     }
 
+    @Test
+    void handlesRollbackErrorInMethod() {
+        this.contextRunner
+                .withConfiguration(UserConfigurations.of(DummyService.class))
+                .withPropertyValues("celesta.h2.inMemory:true")
+                .run((context -> {
+                    try (Celesta celesta = context.getBean(Celesta.class)) {
+                        DummyService srv = context.getBean(DummyService.class);
+                        CallContext cc = new SystemCallContext(){
+                            @Override
+                            public void rollback(){
+                                throw new IllegalStateException("no rollback");
+                            }
+                        };
+                        assertFalse(cc.isClosed());
+                        assertEquals("no rollback",
+                                assertThrows(IllegalStateException.class,
+                                        () -> srv.exception(cc)
+                                ).getMessage());
+                        assertTrue(cc.isClosed());
+                        shutDownH2(celesta);
+                    }
+                }));
+    }
+
     private void shutDownH2(Celesta celesta) throws SQLException {
         celesta.getConnectionPool().get().createStatement().execute("SHUTDOWN");
+    }
+
+    @Test
+    void handlesCallContextActivationFailure() {
+        Celesta celesta = mock(Celesta.class);
+        when(celesta.getConnectionPool()).thenThrow(new IllegalStateException("no connections"));
+        CallContext ctx = new SystemCallContext();
+
+        ProceedingJoinPoint jp = mock(ProceedingJoinPoint.class);
+        Signature signature = mock(Signature.class);
+        when(signature.toShortString()).thenReturn("foo");
+        when(jp.getArgs()).thenReturn(new Object[]{ctx});
+        when(jp.getSignature()).thenReturn(signature);
+
+        CelestaTransactionAspect aspect = new CelestaTransactionAspect(celesta);
+        assertEquals("no connections",
+                assertThrows(IllegalStateException.class,
+                        () -> aspect.execEntryPoint(jp)).getMessage());
     }
 
 }

--- a/src/test/java/ru/curs/celesta/transaction/CelestaTransactionTest.java
+++ b/src/test/java/ru/curs/celesta/transaction/CelestaTransactionTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import ru.curs.celesta.CallContext;
 import ru.curs.celesta.Celesta;
 import ru.curs.celesta.SystemCallContext;
+import ru.curs.celesta.dbutils.IProfiler;
 import ru.curs.celesta.spring.boot.autoconfigure.CelestaAutoConfiguration;
 
 import java.sql.SQLException;
@@ -121,6 +122,7 @@ public class CelestaTransactionTest {
     void handlesCallContextActivationFailure() {
         Celesta celesta = mock(Celesta.class);
         when(celesta.getConnectionPool()).thenThrow(new IllegalStateException("no connections"));
+        when(celesta.getProfiler()).thenReturn(mock(IProfiler.class));
         CallContext ctx = new SystemCallContext();
 
         ProceedingJoinPoint jp = mock(ProceedingJoinPoint.class);
@@ -130,9 +132,11 @@ public class CelestaTransactionTest {
         when(jp.getSignature()).thenReturn(signature);
 
         CelestaTransactionAspect aspect = new CelestaTransactionAspect(celesta);
+        assertFalse(ctx.isClosed());
         assertEquals("no connections",
                 assertThrows(IllegalStateException.class,
                         () -> aspect.execEntryPoint(jp)).getMessage());
+        assertTrue(ctx.isClosed());
     }
 
 }


### PR DESCRIPTION
`CelestaTransactionAspect` had faulty error handling: in case of error in `CallContext` activation phase (e. g. because of database connection problems), it tried to `rollback` non-activated context, which produced `NullPointerException`, and that totally masked the real cause of problems.