### PR TITLE
[PK-226] spring-boot-starter-celesta doesn't handle score from several

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 [![Build Status](https://ci.corchestra.ru/buildStatus/icon?job=spring-boot-starter-celesta/dev)](https://ci.corchestra.ru/job/spring-boot-starter-celesta/job/dev/)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/198302c195b44bfb8dcd14bf83550f6d)](https://www.codacy.com/app/CourseOrchestra/spring-boot-starter-celesta?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=CourseOrchestra/spring-boot-starter-celesta&amp;utm_campaign=Badge_Grade)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/ru.curs/spring-boot-starter-celesta/badge.svg)](https://maven-badges.herokuapp.com/maven-central/ru.curs/spring-boot-starter-celesta)
+
+## Configuration properties
+  
+* **scorePath** _(optional)_ - comma separated list of score location patterns, f.e.:
+
+    * `classpath*:score`
+    * `classpath:score,classpath:testScore`
+    * `file:///~/myScore`
+
+* _TODO: others_

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>ru.curs</groupId>
     <artifactId>spring-boot-starter-celesta</artifactId>
-    <version>2.0.7-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <name>spring-boot-starter-celesta</name>
     <description>Celesta integration with Spring Boot</description>
     <packaging>jar</packaging>
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!--dependency versions -->
-        <celesta.version>7.0.11</celesta.version>
+        <celesta.version>7.1.1</celesta.version>
         <checkstyle.version>8.18</checkstyle.version>
         <junit.platform.version>1.0.0</junit.platform.version>
         <junit.version>5.1.0</junit.version>

--- a/src/main/java/ru/curs/celesta/spring/boot/autoconfigure/CelestaProperties.java
+++ b/src/main/java/ru/curs/celesta/spring/boot/autoconfigure/CelestaProperties.java
@@ -12,7 +12,7 @@ import java.util.LinkedHashSet;
 @ConfigurationProperties(prefix = "celesta")
 public class CelestaProperties {
 
-    private String scorePath = "classpath:score";
+    private String scorePath;
     private JdbcProperties jdbc;
     private H2Properties h2;
     private boolean skipDbUpdate = false;

--- a/src/main/java/ru/curs/celesta/transaction/CelestaTransactionAspect.java
+++ b/src/main/java/ru/curs/celesta/transaction/CelestaTransactionAspect.java
@@ -4,7 +4,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import ru.curs.celesta.CallContext;
-import ru.curs.celesta.Celesta;
+import ru.curs.celesta.ICelesta;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -14,9 +14,10 @@ import java.util.Optional;
  */
 @Aspect
 public final class CelestaTransactionAspect {
-    private final Celesta celesta;
 
-    public CelestaTransactionAspect(Celesta celesta) {
+    private final ICelesta celesta;
+
+    public CelestaTransactionAspect(ICelesta celesta) {
         this.celesta = celesta;
     }
 
@@ -54,4 +55,5 @@ public final class CelestaTransactionAspect {
             c.close();
         }
     }
+
 }

--- a/src/test/java/ru/curs/celesta/transaction/CelestaTransactionTest.java
+++ b/src/test/java/ru/curs/celesta/transaction/CelestaTransactionTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import ru.curs.celesta.CallContext;
 import ru.curs.celesta.Celesta;
+import ru.curs.celesta.ICelesta;
 import ru.curs.celesta.SystemCallContext;
 import ru.curs.celesta.dbutils.IProfiler;
 import ru.curs.celesta.spring.boot.autoconfigure.CelestaAutoConfiguration;
@@ -25,12 +26,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CelestaTransactionTest {
-    private static final String SCORE_PATH = "classpath:score";
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(CelestaAutoConfiguration.class))
-            .withPropertyValues("celesta.scorePath:" + SCORE_PATH);
-
+            .withConfiguration(AutoConfigurations.of(CelestaAutoConfiguration.class));
 
     @Test
     void activatesContext() {
@@ -120,7 +118,7 @@ public class CelestaTransactionTest {
 
     @Test
     void handlesCallContextActivationFailure() {
-        Celesta celesta = mock(Celesta.class);
+        ICelesta celesta = mock(ICelesta.class);
         when(celesta.getConnectionPool()).thenThrow(new IllegalStateException("no connections"));
         when(celesta.getProfiler()).thenReturn(mock(IProfiler.class));
         CallContext ctx = new SystemCallContext();


### PR DESCRIPTION
locations
PathMatchingResourcePatternResolver added for multiple score locations
resolving;
'scorePath' property description added to README;
Celesta dependency -> 7.1.1