### PR TITLE
chore: enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,8 @@ updates:
     - 7.3.36
     - 7.3.38
     - 7.3.39
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Adds a `github-actions` package-ecosystem entry to `.github/dependabot.yml` so GitHub Actions workflow dependencies are checked for updates weekly (limit 10 open PRs).

```yaml
  - package-ecosystem: github-actions
    directory: "/"
    schedule:
      interval: weekly
    open-pull-requests-limit: 10
```